### PR TITLE
fix: Replace Devantler.CLIRunner with CLIWrap package

### DIFF
--- a/src/Devantler.KindCLI/Devantler.KindCLI.csproj
+++ b/src/Devantler.KindCLI/Devantler.KindCLI.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.CLIRunner" Version="1.0.33" />
+    <PackageReference Include="CLIWrap" Version="3.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devantler.KindCLI/Kind.cs
+++ b/src/Devantler.KindCLI/Kind.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using CliWrap;
+using CliWrap.Buffered;
 using Devantler.CLIRunner;
 
 namespace Devantler.KindCLI;
@@ -57,11 +58,13 @@ public static class Kind
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    return await CLI.RunAsync(
-      Command.WithArguments(arguments),
-      validation: validation,
-      silent: silent,
-      includeStdErr: includeStdErr,
-      cancellationToken: cancellationToken).ConfigureAwait(false);
+    using var stdOut = Console.OpenStandardInput();
+    using var stdErr = Console.OpenStandardError();
+    var command = Command.WithArguments(arguments)
+      .WithValidation(validation)
+      .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
+      .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
+    var result = await command.ExecuteBufferedAsync(cancellationToken);
+    return (result.ExitCode, result.StandardOutput + result.StandardError);
   }
 }

--- a/src/Devantler.KindCLI/Kind.cs
+++ b/src/Devantler.KindCLI/Kind.cs
@@ -1,7 +1,6 @@
 using System.Runtime.InteropServices;
 using CliWrap;
 using CliWrap.Buffered;
-using Devantler.CLIRunner;
 
 namespace Devantler.KindCLI;
 

--- a/src/Devantler.KindCLI/Kind.cs
+++ b/src/Devantler.KindCLI/Kind.cs
@@ -57,10 +57,12 @@ public static class Kind
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    using var stdOut = Console.OpenStandardInput();
+    using var stdIn = Console.OpenStandardInput();
+    using var stdOut = Console.OpenStandardOutput();
     using var stdErr = Console.OpenStandardError();
     var command = Command.WithArguments(arguments)
       .WithValidation(validation)
+      .WithStandardInputPipe(silent ? PipeSource.Null : PipeSource.FromStream(stdIn))
       .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
       .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
     var result = await command.ExecuteBufferedAsync(cancellationToken);


### PR DESCRIPTION
Switch to using the CLIWrap package for command execution, enhancing the handling of standard output and error streams.