### PR TITLE
fix: change Command property to GetCommand method

### DIFF
--- a/src/DevantlerTech.KindCLI/Kind.cs
+++ b/src/DevantlerTech.KindCLI/Kind.cs
@@ -11,28 +11,25 @@ public static class Kind
   /// <summary>
   /// The Kind CLI command.
   /// </summary>
-  static Command Command
+  public static Command GetCommand()
   {
-    get
-    {
-      string binaryName = "kind";
-      string? pathEnv = Environment.GetEnvironmentVariable("PATH");
+    string binaryName = "kind";
+    string? pathEnv = Environment.GetEnvironmentVariable("PATH");
 
-      if (!string.IsNullOrEmpty(pathEnv))
+    if (!string.IsNullOrEmpty(pathEnv))
+    {
+      string[] paths = pathEnv.Split(Path.PathSeparator);
+      foreach (string dir in paths)
       {
-        string[] paths = pathEnv.Split(Path.PathSeparator);
-        foreach (string dir in paths)
+        string fullPath = Path.Combine(dir, binaryName);
+        if (File.Exists(fullPath))
         {
-          string fullPath = Path.Combine(dir, binaryName);
-          if (File.Exists(fullPath))
-          {
-            return Cli.Wrap(fullPath);
-          }
+          return Cli.Wrap(fullPath);
         }
       }
-
-      throw new FileNotFoundException($"The '{binaryName}' CLI was not found in PATH.");
     }
+
+    throw new FileNotFoundException($"The '{binaryName}' CLI was not found in PATH.");
   }
 
   /// <summary>
@@ -54,7 +51,7 @@ public static class Kind
     using var stdInConsole = input ? Stream.Null : Console.OpenStandardInput();
     using var stdOutConsole = silent ? Stream.Null : Console.OpenStandardOutput();
     using var stdErrConsole = silent ? Stream.Null : Console.OpenStandardError();
-    var command = Command.WithArguments(arguments)
+    var command = GetCommand().WithArguments(arguments)
       .WithValidation(validation)
       .WithStandardInputPipe(PipeSource.FromStream(stdInConsole))
       .WithStandardOutputPipe(PipeTarget.ToStream(stdOutConsole))


### PR DESCRIPTION
Refactor the Command property to a GetCommand method for improved clarity and functionality in retrieving the CLI command.